### PR TITLE
chore: change from sqs to s3 event driven

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -22,14 +22,6 @@ provider:
         - dynamodb:Query
       Resource:
         - arn:aws:dynamodb:ap-northeast-2:${env:AWS_ACCOUNT_ID}:table/${self:custom.dynamoTableNames.${opt:stage, 'dev'}}
-    - Effect: Allow
-      Action:
-        - sqs:SendMessage
-        - sqs:ReceiveMessage
-        - sqs:DeleteMessage
-        - sqs:GetQueueAttributes
-      Resource:
-        - arn:aws:sqs:ap-northeast-2:${env:AWS_ACCOUNT_ID}:${self:custom.queueNames.${opt:stage, 'dev'}}
 
 custom:
   s3BucketNames:
@@ -40,14 +32,6 @@ custom:
     dev: hywep-recruit-dev
     qa: hywep-recruit-qa
     prod: hywep-recruit-prod
-  queueNames:
-    dev: hywep-recruit-queue-dev
-    qa: hywep-recruit-queue-qa
-    prod: hywep-recruit-queue-prod
-  elasticsearchDomainName:
-    dev: hywep-recruit-es-dev
-    qa: hywep-recruit-es-qa
-    prod: hywep-recruit-es-prod
 
 functions:
   process:
@@ -55,9 +39,12 @@ functions:
     timeout: 600
     memorySize: 1024
     events:
-      - sqs:
-          arn: arn:aws:sqs:ap-northeast-2:${env:AWS_ACCOUNT_ID}:${self:custom.queueNames.${opt:stage, 'dev'}}
-          batchSize: 10
+      - s3:
+          bucket: ${self:custom.s3BucketNames.${opt:stage, 'dev'}}
+          event: s3:ObjectCreated:*
+          existing: true
+          rules:
+            - suffix: .json
 
 resources:
   Resources:

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,4 +1,4 @@
-import {SQSHandler} from "aws-lambda";
+import {S3Handler} from "aws-lambda";
 import {EXCLUDE_KEYS, INVALID_VALUES, KEY_MAPPING} from "./constants";
 import {saveToDynamoDB} from "./aws/dynamo";
 import {getS3File} from "./aws/s3";
@@ -17,11 +17,11 @@ import {
     parseStatus
 } from "./internship/internship";
 
-export const handler: SQSHandler = async (event) => {
+export const handler: S3Handler = async (event) => {
     try {
         for (const record of event.Records) {
-            const messageBody = JSON.parse(record.body);
-            const {bucketName, key} = messageBody;
+            const bucketName = record.s3.bucket.name;
+            const key = decodeURIComponent(record.s3.object.key.replace(/\+/g, " "));
 
             console.log(`Processing file from S3: Bucket=${bucketName}, Key=${key}`);
 
@@ -30,7 +30,6 @@ export const handler: SQSHandler = async (event) => {
             const transformedData = jsonData.map(transformData);
 
             await saveToDynamoDB(transformedData);
-            // await saveToElasticsearch(transformedData);
         }
     } catch (error) {
         console.error("Error processing SQS event:", error);


### PR DESCRIPTION
# Add S3 Trigger for Lambda Function

## **Description**

This pull request modifies the the current SQS trigger with an S3 event trigger for the Lambda function. The function will now be invoked whenever a new object is created in the specified S3 bucket. 

### Changes Made:
1. **Updated Lambda Configuration:**
   - Added S3 trigger for the `process` function.
   - Configured the trigger to respond to `s3:ObjectCreated:*` events.
   - Applied a rule to only trigger on `.json` file suffixes.
2. **Updated Lambda Function Code:**
   - Modified the handler to process S3 event records instead of SQS records.
   - Used `decodeURIComponent` to properly handle encoded object keys.
---

## **Related Issue**

#16 

---

## **Motivation and Context**

Switching to an S3 trigger ensures better utilization of resources and aligns with the current workload requirements, as the low volume of messages in the SQS queue made it an inefficient solution.

---

## **How Has This Been Tested?**

### Testing Process:
1. **Unit Tests:**
   - Verified Lambda function invocation with mock S3 events.
2. **Integration Tests:**
   - Uploaded test `.json` files to the configured S3 bucket and ensured the Lambda function was triggered correctly.
3. **Manual Tests:**
   - Tested in the development environment with various `.json` files to ensure proper functionality.

---

## **Screenshots (if appropriate)**

N/A

---

## **Checklist**

- [x] My code follows the code style of this project.
- [x] My changes require updates to documentation.
- [ ] I have added documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

